### PR TITLE
Add support for Wordpress 5.x

### DIFF
--- a/lib/class-wp-rest-any-post-search-controller.php
+++ b/lib/class-wp-rest-any-post-search-controller.php
@@ -2,7 +2,7 @@
 
 defined ( 'ABSPATH' ) or die();
 
-class WP_REST_Search_Controller extends WP_REST_Controller
+class WP_REST_Any_Post_Search_Controller extends WP_REST_Controller
 {
 
     private static $instance;
@@ -553,4 +553,3 @@ class WP_REST_Search_Controller extends WP_REST_Controller
 
 }
 
-$RESTAPISearch = new REST_API_Search();

--- a/rest-api-search.php
+++ b/rest-api-search.php
@@ -3,7 +3,7 @@
 Plugin Name: REST API Search
 Plugin URI:  https://github.com/KCPT19/REST-API-Search
 Description: Adds in the missing search functionality of all post types to the REST API v2 plugin.
-Version:     1.4
+Version:     1.5
 Author:      KCPT
 Author URI:  https://github.com/orgs/KCPT19
 License:     GPL2
@@ -27,9 +27,9 @@ class REST_API_Search
     public function restAPI()
     {
 
-        require_once dirname( __FILE__ ) . '/lib/class-wp-rest-search-controller.php';
+        require_once dirname( __FILE__ ) . '/lib/class-wp-rest-any-post-search-controller.php';
 
-        $this->controller = new WP_REST_Search_Controller();
+        $this->controller = new WP_REST_Any_Post_Search_Controller();
         $this->controller->register_routes();
 
     }


### PR DESCRIPTION
Because Wordpress 5.x added an API for searching we got a class names collision. This PR fixes it and makes the plugin work again.